### PR TITLE
Fix hunger reset bug

### DIFF
--- a/src/components/apps/LifeApp.tsx
+++ b/src/components/apps/LifeApp.tsx
@@ -258,13 +258,13 @@ export function LifeApp({ onBack }: LifeAppProps) {
                   
                   if (freshProfile) {
                     const freshStats = {
-                      health: freshProfile.life_percentage || 100,
-                      hunger: freshProfile.hunger_percentage || 100,
+                      health: (freshProfile.life_percentage ?? 100),
+                      hunger: (freshProfile.hunger_percentage ?? 100),
                       mood: freshProfile.mood?.toString() || "Sentindo-se bem",
-                      alcoholism: freshProfile.alcoholism_percentage || 0,
-                      happiness: freshProfile.happiness_percentage || 100,
-                      energy: freshProfile.energy_percentage || 100,
-                      disease: gameStats.disease || 0 // Add missing disease property
+                      alcoholism: (freshProfile.alcoholism_percentage ?? 0),
+                      happiness: (freshProfile.happiness_percentage ?? 100),
+                      energy: (freshProfile.energy_percentage ?? 100),
+                      disease: (gameStats.disease || 0) // Add missing disease property
                     };
                     
                     // Update local state only to avoid feedback loop; GameContext realtime will sync globally
@@ -425,10 +425,10 @@ export function LifeApp({ onBack }: LifeAppProps) {
                   <span className="text-sm font-medium text-yellow-800 dark:text-yellow-200">Felicidade</span>
                 </div>
                 <Badge variant="outline" className="text-xs bg-white dark:bg-gray-800 text-yellow-700 dark:text-yellow-300 border-yellow-400 dark:border-yellow-600 font-semibold">
-                  {localGameStats.happiness || 100}%
+                  {localGameStats.happiness ?? 100}%
                 </Badge>
               </div>
-              <StatBar label="" value={localGameStats.happiness || 100} color="happiness" />
+              <StatBar label="" value={localGameStats.happiness ?? 100} color="happiness" />
             </CardContent>
           </Card>
 
@@ -441,10 +441,10 @@ export function LifeApp({ onBack }: LifeAppProps) {
                   <span className="text-sm font-medium text-blue-800 dark:text-blue-200">Energia</span>
                 </div>
                 <Badge variant="outline" className="text-xs bg-white dark:bg-gray-800 text-blue-700 dark:text-blue-300 border-blue-400 dark:border-blue-600 font-semibold">
-                  {localGameStats.energy || 100}%
+                  {localGameStats.energy ?? 100}%
                 </Badge>
               </div>
-              <StatBar label="" value={localGameStats.energy || 100} color="energy" />
+              <StatBar label="" value={localGameStats.energy ?? 100} color="energy" />
             </CardContent>
           </Card>
         </div>

--- a/src/contexts/GameContext.tsx
+++ b/src/contexts/GameContext.tsx
@@ -1073,7 +1073,6 @@ export function GameProvider({ children }: { children: ReactNode }) {
             .from('users')
             .update({
               life_percentage: gameStats.health,
-              hunger_percentage: gameStats.hunger,
               alcoholism_percentage: gameStats.alcoholism,
               disease_percentage: gameStats.disease,
               wallet_balance: money
@@ -1266,12 +1265,12 @@ export function GameProvider({ children }: { children: ReactNode }) {
           const userData = payload.new;
           setGameStats(prev => ({
             ...prev,
-            health: userData.life_percentage || prev.health,
-            hunger: userData.hunger_percentage || prev.hunger,
-            happiness: userData.happiness_percentage || prev.happiness,
-            energy: userData.energy_percentage || prev.energy,
-            alcoholism: userData.alcoholism_percentage || prev.alcoholism,
-            disease: userData.disease_percentage || prev.disease
+            health: (userData.life_percentage ?? prev.health),
+            hunger: (userData.hunger_percentage ?? prev.hunger),
+            happiness: (userData.happiness_percentage ?? prev.happiness),
+            energy: (userData.energy_percentage ?? prev.energy),
+            alcoholism: (userData.alcoholism_percentage ?? prev.alcoholism),
+            disease: (userData.disease_percentage ?? prev.disease)
           }));
           
           // Update wallet balance if changed


### PR DESCRIPTION
Stop hunger percentage from resetting to 100 by removing client-side auto-save and correctly handling stat fallbacks with nullish coalescing.

---
<a href="https://cursor.com/background-agent?bcId=bc-53985e41-b39b-470f-b8ff-b8fcf236e9cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-53985e41-b39b-470f-b8ff-b8fcf236e9cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

